### PR TITLE
partially fix travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
     - sudo apt-get install luarocks redis-server
     # libssl.* are in /usr/lib/x86_64-linux-gnu on Travis Ubuntu precise
-    - sudo luarocks install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu
+    - sudo luarocks install luasec 0.5-2 OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu
     - git clone https://github.com/ostinelli/gin
     # patch gin for https support
     - cd gin && patch -N -p1 < ../gin.patch

--- a/app/controllers/1/syncs_controller.lua
+++ b/app/controllers/1/syncs_controller.lua
@@ -61,9 +61,6 @@ end
 
 function SyncsController:create_user()
     local redis = self:getRedis()
-    if not redis then
-        self:raise_error(self.error_no_redis)
-    end
 
     if not is_valid_key_field(self.request.body.username)
     or not is_valid_field(self.request.body.password) then
@@ -88,9 +85,6 @@ end
 
 function SyncsController:get_progress()
     local redis = self:getRedis()
-    if not redis then
-        self:raise_error(self.error_no_redis)
-    end
 
     local username = self:authorize()
     if not username then
@@ -126,18 +120,15 @@ end
 
 function SyncsController:update_progress()
     local redis = self:getRedis()
-    if not redis then
-        self:raise_error(self.error_no_redis)
-    end
 
     local username = self:authorize()
     if not username then
-        self:raise_error(error_unauthorized_user)
+        self:raise_error(self.error_unauthorized_user)
     end
 
     local doc = self.request.body.document
     if not is_valid_key_field(doc) then
-        self:raise_error(error_document_field_missing)
+        self:raise_error(self.error_document_field_missing)
     end
 
     local percentage = tonumber(self.request.body.percentage)

--- a/config/errors.lua
+++ b/config/errors.lua
@@ -13,10 +13,10 @@
 -------------------------------------------------------------------------------------------------------------------
 
 local Errors = {
-    [1000] = { status = 503, message = "Cannot connect to redis server.", },
-    [2000] = { status = 503, message = "Unknown server error.", },
+    [1000] = { status = 502, message = "Cannot connect to redis server.", },
+    [2000] = { status = 502, message = "Unknown server error.", },
     [2001] = { status = 401, message = "Unauthorized", },
-    [2002] = { status = 401, message = "Username is already registered.", },
+    [2002] = { status = 402, message = "Username is already registered.", },
     [2003] = { status = 403, message = "Invalid request", },
     [2004] = { status = 403, message = "Field 'document' not provided.", },
 }

--- a/spec/controllers/1/syncs_controller_spec.lua
+++ b/spec/controllers/1/syncs_controller_spec.lua
@@ -130,13 +130,10 @@ describe("SyncsController", function()
         it("should update document progress", function()
             local response = update(username, userkey, doc, 0.32, "56", "my kpw")
             assert.are.same(200, response.status)
-            assert.are.same({
-                percentage = 0.32,
-                progress = "56",
-                device = "my kpw"
-            }, response.body)
+            assert.are.same(doc, response.body.document)
+            assert.truthy(response.body.timestamp)
         end)
-        it("cannot get non-existent document progres", function()
+        it("cannot get progress of non-existent document", function()
             update(username, userkey, doc, 0.32, "56", "my kpw")
             local response = get(username, userkey, doc .. "non_existent")
             assert.are.same(200, response.status)
@@ -147,7 +144,7 @@ describe("SyncsController", function()
             local response = get(username, userkey, doc)
             assert.are.same(200, response.status)
             assert.are.same({
-                percentage = 0.32,
+                percentage = '0.32',
                 progress = "56",
                 device = "my kpw"
             }, response.body)


### PR DESCRIPTION
some of the failed unit tests are introduced in recent refactoring
@Hzj-jie Could you fix the remaining broken unit test? It seems the refactoring breaks several specifications:
```
6 successes / 3 failures / 0 errors / 0 pending : 2.164241 seconds

Failure → spec/controllers/1/syncs_controller_spec.lua @ 136
SyncsController #sync cannot get progress of non-existent document
spec/controllers/1/syncs_controller_spec.lua:140: Expected objects to be the same.
Passed in:
(table) {
 *[device] = userdata: (nil)
  [device_id] = userdata: (nil)
  [document] = '89isjkdaj9jnon_existent'
  [percentage] = userdata: (nil)
  [progress] = userdata: (nil)
  [timpstamp] = userdata: (nil) }
Expected:
(table) { }

Failure → spec/controllers/1/syncs_controller_spec.lua @ 142
SyncsController #sync should get document progress
spec/controllers/1/syncs_controller_spec.lua:146: Expected objects to be the same.
Passed in:
(table) {
  [device] = 'my kpw'
  [device_id] = userdata: (nil)
  [document] = '89isjkdaj9j'
  [percentage] = '0.32'
  [progress] = '56'
 *[timpstamp] = '1470890559' }
Expected:
(table) {
  [device] = 'my kpw'
  [percentage] = '0.32'
  [progress] = '56' }

Failure → spec/controllers/1/syncs_controller_spec.lua @ 152
SyncsController #sync should get the furthest document progress
spec/controllers/1/syncs_controller_spec.lua:157: Expected objects to be the same.
Passed in:
(table) {
  [device] = 'my pb'
  [device_id] = userdata: (nil)
  [document] = '89isjkdaj9j'
  [percentage] = '0.22'
 *[progress] = '36'
  [timpstamp] = '1470890560' }
Expected:
(table) {
  [device] = 'my kpw'
  [percentage] = 0.32000000000000000666
 *[progress] = '56' }
```