### PR TITLE
Fix docker build error on MacOS Ventura 13.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
 
 # libssl.* are in /usr/lib/x86_64-linux-gnu on Travis Ubuntu precise
 RUN luarocks install --verbose luasocket \
-    && luarocks install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu \
+    && OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu OPENSSL_DIR=/usr/ luarocks install luasec \
     && luarocks install redis-lua \
     && luarocks install busted \
     && rm -rf /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
 
 # libssl.* are in /usr/lib/x86_64-linux-gnu on Travis Ubuntu precise
 RUN luarocks install --verbose luasocket \
-    && OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu OPENSSL_DIR=/usr/ luarocks install luasec \
+    && luarocks install luasec \
     && luarocks install redis-lua \
     && luarocks install busted \
     && rm -rf /tmp/*


### PR DESCRIPTION
Fixes this error: 
```
7.129 Error: Could not find header file for OPENSSL
7.129   No file openssl/ssl.h in /usr/local/include
7.129   No file openssl/ssl.h in /include
7.129 You may have to install OPENSSL in your system and/or pass OPENSSL_DIR or OPENSSL_INCDIR to the luarocks command.
7.129 Example: luarocks install luasec OPENSSL_DIR=/usr/local
------
Dockerfile:29
--------------------
  28 |     # libssl.* are in /usr/lib/x86_64-linux-gnu on Travis Ubuntu precise
  29 | >>> RUN luarocks install --verbose luasocket \
  30 | >>>     && luarocks install luasec OPENSSL_LIBDIR=/usr/lib/x86_64-linux-gnu \
  31 | >>>     && luarocks install redis-lua \
  32 | >>>     && luarocks install busted \
  33 | >>>     && rm -rf /tmp/*
  34 |
--------------------
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-sync-server/20)
<!-- Reviewable:end -->
