### PR TITLE
Add documentation on how to run the server behind a reverse proxy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ curl -k -v -H "Accept: application/vnd.koreader.v1+json" https://localhost:7200/
 # should return {"state":"OK"}
 ```
 
+As you can see, the server responds over HTTPS using a self-signed certificate. If you'd like to run the server behind a reverse proxy and let the proxy handle TLS termination, run the server on port `17200` instead of `7200`. As an example, your Traefik V3 configuration could look like this:
+
+```bash
+  kosync:
+    # ...
+    labels:
+      - traefik.enable=true
+      - 'traefik.http.routers.kosync.rule=Host(`kosync.example.com`)'
+      - 'traefik.http.services.kosync.loadbalancer.server.port=17200'
+```
+
 Privacy and security
 ========
 


### PR DESCRIPTION
As the description says.

I was trying to put the sync-server behind Traefik and initially it didn't work. I then stumbled upon #14 which had instructions on how to fix the problem. So, I thought I'd raise a small PR to improve the documentation as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-sync-server/23)
<!-- Reviewable:end -->
