### PR TITLE
Add self-service account deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ As you can see, the server responds over HTTPS using a self-signed certificate. 
       - 'traefik.http.services.kosync.loadbalancer.server.port=17200'
 ```
 
+Deleting an account
+===================
+
+`DELETE /users/me` uses the `x-auth-user` and `x-auth-key` headers to delete an
+account and all its reading progress. Success returns HTTP 200 with
+`{"deleted":true}`. Invalid credentials return HTTP 401 (code 2001).
+
+An absent account returns HTTP 404 (code 2006, `Account not found.`), after
+removing any orphaned user data. This specific response confirms deletion after a
+lost response; a generic 404 or 401 does not.
+
+No deletion records are retained. Usernames can be registered again immediately
+with empty progress. Use a different password when re-registering: a stale deletion
+request cannot be distinguished from a new one if both credentials are reused.
+
 Privacy and security
 ========
 
@@ -88,28 +103,3 @@ are secured by HTTPS (Hypertext Transfer Protocol Secure) connections.
 
 [licence-badge]:http://img.shields.io/badge/licence-AGPL-brightgreen.svg
 [dockerfile]:https://github.com/koreader/koreader-sync-server/blob/master/Dockerfile
-
-### Deleting an account
-
-`DELETE /users/me` accepts the normal `x-auth-user` / `x-auth-key` headers and
-returns `{ "deleted": true }`. The username and key must be nonempty and the
-username must not contain a colon. For an existing account the key must match.
-Deletion atomically checks authentication and removes all `user:<username>:`
-keys, including credentials and reading progress. An absent account returns HTTP
-404 with `{ "code": 2006, "message": "Account not found." }`; any orphaned user
-keys are removed. A wrong key for an existing account still returns HTTP 401,
-code 2001. Callers can treat the explicit account-not-found result as completed
-deletion when reconciling a lost response; a generic 404 or 401 is not sufficient.
-
-No request IDs, deletion markers, or credentials are retained by the server.
-The username may be registered again immediately, with empty progress. A deletion
-retry with the old password cannot delete a re-registered account with a different
-password. The server cannot distinguish generations that reuse both the same
-username and password. Applications needing this distinction should generate fresh
-credentials when creating another account.
-
-Progress updates check authentication at the Redis write so an earlier
-successful authorization cannot write after account removal. Registration uses
-`SETNX` to avoid overwriting credentials when registrations race. An independent
-signup arriving after deletion may create the username again; deletion does not
-reserve or permanently block usernames.

--- a/README.md
+++ b/README.md
@@ -88,3 +88,28 @@ are secured by HTTPS (Hypertext Transfer Protocol Secure) connections.
 
 [licence-badge]:http://img.shields.io/badge/licence-AGPL-brightgreen.svg
 [dockerfile]:https://github.com/koreader/koreader-sync-server/blob/master/Dockerfile
+
+### Deleting an account
+
+`DELETE /users/me` accepts the normal `x-auth-user` / `x-auth-key` headers and
+returns `{ "deleted": true }`. The username and key must be nonempty and the
+username must not contain a colon. For an existing account the key must match.
+Deletion atomically checks authentication and removes all `user:<username>:`
+keys, including credentials and reading progress. An absent account returns HTTP
+404 with `{ "code": 2006, "message": "Account not found." }`; any orphaned user
+keys are removed. A wrong key for an existing account still returns HTTP 401,
+code 2001. Callers can treat the explicit account-not-found result as completed
+deletion when reconciling a lost response; a generic 404 or 401 is not sufficient.
+
+No request IDs, deletion markers, or credentials are retained by the server.
+The username may be registered again immediately, with empty progress. A deletion
+retry with the old password cannot delete a re-registered account with a different
+password. The server cannot distinguish generations that reuse both the same
+username and password. Applications needing this distinction should generate fresh
+credentials when creating another account.
+
+Progress updates check authentication at the Redis write so an earlier
+successful authorization cannot write after account removal. Registration uses
+`SETNX` to avoid overwriting credentials when registrations race. An independent
+signup arriving after deletion may create the username again; deletion does not
+reserve or permanently block usernames.

--- a/app/controllers/1/syncs_controller.lua
+++ b/app/controllers/1/syncs_controller.lua
@@ -21,6 +21,26 @@ local SyncsController = {
 
 local null = ngx.null
 
+local delete_user_script = [[
+local cursor = "0"
+local prefix = ARGV[1]
+local keys = {}
+repeat
+    local result = redis.call("SCAN", cursor, "COUNT", 100)
+    cursor = result[1]
+    for _, key in ipairs(result[2]) do
+        if string.sub(key, 1, string.len(prefix)) == prefix then
+            table.insert(keys, key)
+        end
+    end
+until cursor == "0"
+
+for _, key in ipairs(keys) do
+    redis.call("DEL", key)
+end
+return #keys
+]]
+
 -- Whether a field is valid, i.e. not an empty string.
 local function is_valid_field(field)
     return type(field) == "string" and string.len(field) > 0
@@ -86,6 +106,23 @@ end
 
 function SyncsController:create_user_disabled()
     self:raise_error(self.error_user_registration_disabled)
+end
+
+function SyncsController:delete_user()
+    local redis = self:getRedis()
+
+    local username = self:authorize()
+    if not username then
+        self:raise_error(self.error_unauthorized_user)
+    end
+
+    local prefix = "user:" .. username .. ":"
+    local deleted, err = redis:eval(delete_user_script, 0, prefix)
+    if not deleted then
+        self:raise_error(self.error_internal)
+    end
+
+    return 200, { deleted = true }
 end
 
 function SyncsController:get_progress()

--- a/app/controllers/1/syncs_controller.lua
+++ b/app/controllers/1/syncs_controller.lua
@@ -57,7 +57,7 @@ local update_progress_script = [[
 if redis.call("GET", KEYS[1]) ~= ARGV[1] then
     return 0
 end
-redis.call("HMSET", KEYS[2], unpack(ARGV, 2))
+redis.call("HSET", KEYS[2], unpack(ARGV, 2))
 return 1
 ]]
 

--- a/app/controllers/1/syncs_controller.lua
+++ b/app/controllers/1/syncs_controller.lua
@@ -17,11 +17,18 @@ local SyncsController = {
     -- Do we really need to handle 'document' field specifically?
     error_document_field_missing = 2004,
     error_user_registration_disabled = 2005,
+    error_account_not_found = 2006,
 }
 
 local null = ngx.null
 
+-- Authenticate and delete in one operation. Distinguish an absent account from
+-- a wrong key so callers can reconcile retries without retaining tombstones.
 local delete_user_script = [[
+local current_key = redis.call("GET", KEYS[1])
+if current_key and current_key ~= ARGV[2] then
+    return 0
+end
 local cursor = "0"
 local prefix = ARGV[1]
 local keys = {}
@@ -38,7 +45,20 @@ until cursor == "0"
 for _, key in ipairs(keys) do
     redis.call("DEL", key)
 end
-return #keys
+if not current_key then
+    return 2
+end
+return 1
+]]
+
+-- Check authentication at the write itself: a request that authorized before
+-- deletion must not recreate a document afterward.
+local update_progress_script = [[
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+    return 0
+end
+redis.call("HMSET", KEYS[2], unpack(ARGV, 2))
+return 1
 ]]
 
 -- Whether a field is valid, i.e. not an empty string.
@@ -88,20 +108,14 @@ function SyncsController:create_user()
         self:raise_error(self.error_invalid_fields)
     end
 
-    local user_key = string.format(self.user_key, self.request.body.username)
-    local user, err = redis:get(user_key)
-    if user == null then
-        ok, err = redis:set(user_key, self.request.body.password)
-        if not ok then
-            self:raise_error(self.error_internal)
-        else
-            return 201, { username = self.request.body.username }
-        end
-    elseif user then
+    local created, err = redis:setnx(string.format(self.user_key, self.request.body.username),
+        self.request.body.password)
+    if created == 0 then
         self:raise_error(self.error_user_exists)
-    else
+    elseif created ~= 1 then
         self:raise_error(self.error_internal)
     end
+    return 201, { username = self.request.body.username }
 end
 
 function SyncsController:create_user_disabled()
@@ -109,16 +123,20 @@ function SyncsController:create_user_disabled()
 end
 
 function SyncsController:delete_user()
-    local redis = self:getRedis()
-
-    local username = self:authorize()
-    if not username then
+    local username = self.request.headers['x-auth-user']
+    local current_key = self.request.headers['x-auth-key']
+    if not is_valid_key_field(username) or not is_valid_field(current_key) then
         self:raise_error(self.error_unauthorized_user)
     end
 
-    local prefix = "user:" .. username .. ":"
-    local deleted, err = redis:eval(delete_user_script, 0, prefix)
-    if not deleted then
+    local redis = self:getRedis()
+    local deleted, err = redis:eval(delete_user_script, 1,
+        string.format(self.user_key, username), "user:" .. username .. ":", current_key)
+    if deleted == 0 then
+        self:raise_error(self.error_unauthorized_user)
+    elseif deleted == 2 then
+        self:raise_error(self.error_account_not_found)
+    elseif deleted ~= 1 then
         self:raise_error(self.error_internal)
     end
 
@@ -194,14 +212,22 @@ function SyncsController:update_progress()
     local timestamp = os.time()
     if percentage and progress and device then
         local key = string.format(self.doc_key, username, doc)
-        local ok, err = redis:hmset(key, {
-            [self.percentage_field] = percentage,
-            [self.progress_field] = progress,
-            [self.device_field] = device,
-            [self.device_id_field] = device_id,
-            [self.timestamp_field] = timestamp,
-        })
-        if not ok then
+        local fields = {
+            self.request.headers['x-auth-key'],
+            self.percentage_field, percentage,
+            self.progress_field, progress,
+            self.device_field, device,
+            self.timestamp_field, timestamp,
+        }
+        if device_id ~= nil then
+            table.insert(fields, self.device_id_field)
+            table.insert(fields, device_id)
+        end
+        local updated, err = redis:eval(update_progress_script, 2,
+            string.format(self.user_key, username), key, unpack(fields))
+        if updated == 0 then
+            self:raise_error(self.error_unauthorized_user)
+        elseif updated ~= 1 then
             self:raise_error(self.error_internal)
         end
         return 200, {

--- a/config/errors.lua
+++ b/config/errors.lua
@@ -20,6 +20,7 @@ local Errors = {
     [2003] = { status = 403, message = "Invalid request", },
     [2004] = { status = 403, message = "Field 'document' not provided.", },
     [2005] = { status = 402, message = "User registration is disabled.", },
+    [2006] = { status = 404, message = "Account not found.", },
 }
 
 return Errors

--- a/config/routes.lua
+++ b/config/routes.lua
@@ -11,6 +11,7 @@ else
     v1:POST("/users/create", { controller = "syncs", action = "create_user_disabled" })
 end
 v1:GET("/users/auth", { controller = "syncs", action = "auth_user" })
+v1:DELETE("/users/me", { controller = "syncs", action = "delete_user" })
 v1:PUT("/syncs/progress", { controller = "syncs", action = "update_progress" })
 v1:GET("/syncs/progress/:document", { controller = "syncs", action = "get_progress" })
 v1:GET("/healthcheck", { controller = "syncs", action = "healthcheck" })

--- a/spec/controllers/1/syncs_controller_spec.lua
+++ b/spec/controllers/1/syncs_controller_spec.lua
@@ -167,6 +167,68 @@ describe("SyncsController", function()
         end)
     end)
 
+    describe("#deletion retries", function()
+        local function client()
+            local connection = require("redis").connect("127.0.0.1", 6379)
+            connection:select(2)
+            return connection
+        end
+
+        it("distinguishes repeated and absent accounts without retaining records", function()
+            register("reader", "key")
+            update("reader", "key", "doc", 0.32, "56", "device")
+            assert.are.same(200, delete_user("reader", "key").status)
+            local retry = delete_user("reader", "key")
+            assert.are.same(404, retry.status)
+            assert.are.same({ code = 2006, message = "Account not found." }, retry.body)
+            assert.are.same(404, delete_user("missing", "key").status)
+            local redis = client()
+            assert.are.same({}, redis:keys("*"))
+            redis:quit()
+        end)
+
+        it("allows username reuse and rejects the old key after re-registration", function()
+            register("reader", "old-key")
+            delete_user("reader", "old-key")
+            assert.are.same(401, update("reader", "old-key", "doc", 0.3, "56", "device").status)
+            assert.are.same(201, register("reader", "new-key").status)
+            assert.are.same(401, delete_user("reader", "old-key").status)
+            assert.are.same(200, authorize("reader", "new-key").status)
+            assert.are.same({}, get("reader", "new-key", "doc").body)
+            assert.are.same(200, delete_user("reader", "new-key").status)
+            assert.are.same(201, register("reader", "new-key").status)
+        end)
+
+        it("requires well-formed authentication even when the account is absent", function()
+            for _, response in ipairs({ delete_user(nil, "key"), delete_user("", "key"),
+                delete_user("reader:other", "key"), delete_user("reader", nil), delete_user("reader", "") }) do
+                assert.are.same(401, response.status)
+            end
+        end)
+
+        it("cleans orphaned progress for an absent account without touching another user", function()
+            register("other", "other-key")
+            local redis = client()
+            redis:hmset("user:missing:document:doc", "progress", "56")
+            redis:quit()
+            assert.are.same(404, delete_user("missing", "key").status)
+            redis = client()
+            assert.are.same({}, redis:keys("user:missing:*"))
+            redis:quit()
+            assert.are.same(200, authorize("other", "other-key").status)
+        end)
+
+        it("fails closed on Redis type errors", function()
+            local redis = client()
+            redis:lpush("user:broken:key", "wrong-type")
+            redis:quit()
+            assert.are.same(502, delete_user("broken", "key").status)
+            redis = client()
+            assert.are.same({ "wrong-type" }, redis:lrange("user:broken:key", 0, -1))
+            redis:quit()
+        end)
+    end)
+
     describe("#sync", function()
         local username, userkey, doc = "user1", "passwd123", "89isjkdaj9j"
         before_each(function()

--- a/spec/controllers/1/syncs_controller_spec.lua
+++ b/spec/controllers/1/syncs_controller_spec.lua
@@ -138,7 +138,7 @@ describe("SyncsController", function()
 
         it("deletes the user and all progress", function()
             local username, userkey = "user1", "passwd123"
-            local doc1, doc2 = "document-one", "document-two"
+            local doc1, doc2 = "document1", "document2"
             register(username, userkey)
             update(username, userkey, doc1, 0.32, "56", "my kpw")
             update(username, userkey, doc2, 0.64, "112", "my kpw")
@@ -157,13 +157,13 @@ describe("SyncsController", function()
         it("does not treat glob characters in usernames as wildcards", function()
             register("user*one", "password-one")
             register("userXone", "password-two")
-            update("user*one", "password-one", "document-one", 0.32, "56", "device one")
-            update("userXone", "password-two", "document-two", 0.64, "112", "device two")
+            update("user*one", "password-one", "document1", 0.32, "56", "device one")
+            update("userXone", "password-two", "document2", 0.64, "112", "device two")
 
             assert.are.same(200, delete_user("user*one", "password-one").status)
             assert.are.same(200, authorize("userXone", "password-two").status)
-            assert.are.same("document-two",
-                get("userXone", "password-two", "document-two").body.document)
+            assert.are.same("document2",
+                get("userXone", "password-two", "document2").body.document)
         end)
     end)
 

--- a/spec/controllers/1/syncs_controller_spec.lua
+++ b/spec/controllers/1/syncs_controller_spec.lua
@@ -42,6 +42,20 @@ describe("SyncsController", function()
         return response
     end
 
+    local function delete_user(username, userkey)
+        local response = hit({
+            scheme = "https",
+            method = "DELETE",
+            path = "/users/me",
+            headers = {
+                ["x-auth-user"] = username,
+                ["x-auth-key"] = userkey,
+            },
+        })
+
+        return response
+    end
+
     local function get(username, userkey, document)
         local response = hit({
             scheme = "https",
@@ -108,6 +122,48 @@ describe("SyncsController", function()
             response = authorize(username, userkey)
             assert.are.same(200, response.status)
             assert.are.same("OK", response.body.authorized)
+        end)
+    end)
+
+    describe("#delete", function()
+        it("requires valid credentials", function()
+            local username, userkey = "user1", "passwd123"
+            register(username, userkey)
+
+            local response = delete_user(username, "wrong_password")
+            assert.are.same(401, response.status)
+            assert.are.same({code = 2001, message = "Unauthorized"}, response.body)
+            assert.are.same(200, authorize(username, userkey).status)
+        end)
+
+        it("deletes the user and all progress", function()
+            local username, userkey = "user1", "passwd123"
+            local doc1, doc2 = "document-one", "document-two"
+            register(username, userkey)
+            update(username, userkey, doc1, 0.32, "56", "my kpw")
+            update(username, userkey, doc2, 0.64, "112", "my kpw")
+
+            local response = delete_user(username, userkey)
+            assert.are.same(200, response.status)
+            assert.are.same({ deleted = true }, response.body)
+            assert.are.same(401, authorize(username, userkey).status)
+
+            -- Re-registering the username should start with no old progress.
+            assert.are.same(201, register(username, "new-password").status)
+            assert.are.same({}, get(username, "new-password", doc1).body)
+            assert.are.same({}, get(username, "new-password", doc2).body)
+        end)
+
+        it("does not treat glob characters in usernames as wildcards", function()
+            register("user*one", "password-one")
+            register("userXone", "password-two")
+            update("user*one", "password-one", "document-one", 0.32, "56", "device one")
+            update("userXone", "password-two", "document-two", 0.64, "112", "device two")
+
+            assert.are.same(200, delete_user("user*one", "password-one").status)
+            assert.are.same(200, authorize("userXone", "password-two").status)
+            assert.are.same("document-two",
+                get("userXone", "password-two", "document-two").body.document)
         end)
     end)
 


### PR DESCRIPTION
Adds `DELETE /users/me`, authenticated with the existing `x-auth-user` and `x-auth-key` headers, so users can remove their account and all reading progress.

Authentication and deletion run atomically in Redis. Progress writes recheck authentication at write time to prevent in-flight requests from recreating deleted data, and registration uses `SETNX` to prevent concurrent signups from overwriting credentials.

Successful deletion returns `200 {"deleted":true}`. Missing accounts return HTTP 404 with error code 2006, allowing clients to reconcile retries. Incorrect credentials for an existing account return HTTP 401.

Usernames can be registered again immediately with empty progress. The README documents retry behavior and the limitations of reusing identical credentials.

Includes controller specs for authentication, progress removal, username isolation, retries, re-registration, orphan cleanup, and Redis errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-sync-server/50)
<!-- Reviewable:end -->
