### PR TITLE
Add authenticated password changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,45 @@ As you can see, the server responds over HTTPS using a self-signed certificate. 
       - 'traefik.http.services.kosync.loadbalancer.server.port=17200'
 ```
 
+Changing a password
+======================
+
+`PUT /users/password` changes an existing account's authentication key. Send the
+current username and key in the usual `x-auth-user` and `x-auth-key` headers, and
+send the replacement key in the JSON body:
+
+```http
+PUT /users/password
+Accept: application/vnd.koreader.v1+json
+Content-Type: application/json
+x-auth-user: <username>
+x-auth-key: <current authentication key>
+
+{"password":"<replacement authentication key>"}
+```
+
+Like registration, `password` is the client-derived authentication key. KOReader
+clients use the MD5 hash of the user's password; the server stores the supplied
+value without hashing it again. Both keys must be nonempty strings.
+
+Success returns HTTP 200 with `{"updated":true}`. The username, document progress,
+and other account records are unchanged. Clients must use the replacement key
+for subsequent requests; update the saved password on all connected readers.
+This endpoint requires the current key and does not provide forgotten-password
+recovery or create missing accounts.
+
+The current-key check and replacement run atomically in Redis. When competing
+requests supply the same old key and different new keys, only one can succeed.
+A retry using an old key after a successful change returns HTTP 401, just like an
+incorrect key or nonexistent user. If a response is lost, confirm the proposed
+replacement with `GET /users/auth` before attempting another change. Supplying the
+current key as the replacement is allowed and leaves authentication unchanged.
+
+Invalid replacement values return HTTP 403 (code 2003); Redis failures use the
+existing HTTP 502 errors. Use HTTPS when accessing this endpoint. Operators who
+manage password changes through a separate trusted API can restrict this route
+at their reverse proxy.
+
 Privacy and security
 ========
 

--- a/README.md
+++ b/README.md
@@ -65,43 +65,19 @@ As you can see, the server responds over HTTPS using a self-signed certificate. 
 ```
 
 Changing a password
-======================
+===================
 
-`PUT /users/password` changes an existing account's authentication key. Send the
-current username and key in the usual `x-auth-user` and `x-auth-key` headers, and
-send the replacement key in the JSON body:
+`PUT /users/password` uses the current `x-auth-user` and `x-auth-key` headers and a
+JSON body of `{"password":"<replacement key>"}`. As with registration, supply a
+nonempty client-derived key (KOReader uses the password's MD5 hash).
 
-```http
-PUT /users/password
-Accept: application/vnd.koreader.v1+json
-Content-Type: application/json
-x-auth-user: <username>
-x-auth-key: <current authentication key>
+Success returns HTTP 200 with `{"updated":true}` and preserves reading progress.
+Update the saved password on all connected readers. This requires the current key;
+it does not provide forgotten-password recovery.
 
-{"password":"<replacement authentication key>"}
-```
-
-Like registration, `password` is the client-derived authentication key. KOReader
-clients use the MD5 hash of the user's password; the server stores the supplied
-value without hashing it again. Both keys must be nonempty strings.
-
-Success returns HTTP 200 with `{"updated":true}`. The username, document progress,
-and other account records are unchanged. Clients must use the replacement key
-for subsequent requests; update the saved password on all connected readers.
-This endpoint requires the current key and does not provide forgotten-password
-recovery or create missing accounts.
-
-The current-key check and replacement run atomically in Redis. When competing
-requests supply the same old key and different new keys, only one can succeed.
-A retry using an old key after a successful change returns HTTP 401, just like an
-incorrect key or nonexistent user. If a response is lost, confirm the proposed
-replacement with `GET /users/auth` before attempting another change. Supplying the
-current key as the replacement is allowed and leaves authentication unchanged.
-
-Invalid replacement values return HTTP 403 (code 2003); Redis failures use the
-existing HTTP 502 errors. Use HTTPS when accessing this endpoint. Operators who
-manage password changes through a separate trusted API can restrict this route
-at their reverse proxy.
+Incorrect credentials and stale retries return HTTP 401. If a response is lost,
+confirm the replacement key with `GET /users/auth`. Invalid replacement values
+return HTTP 403 (code 2003).
 
 Privacy and security
 ========

--- a/app/controllers/1/syncs_controller.lua
+++ b/app/controllers/1/syncs_controller.lua
@@ -21,6 +21,16 @@ local SyncsController = {
 
 local null = ngx.null
 
+-- Authenticate and update in one operation so concurrent changes using the
+-- same current key cannot both succeed. Document keys are never touched.
+local update_password_script = [[
+if redis.call("GET", KEYS[1]) ~= ARGV[1] then
+    return 0
+end
+redis.call("SET", KEYS[1], ARGV[2])
+return 1
+]]
+
 -- Whether a field is valid, i.e. not an empty string.
 local function is_valid_field(field)
     return type(field) == "string" and string.len(field) > 0
@@ -86,6 +96,30 @@ end
 
 function SyncsController:create_user_disabled()
     self:raise_error(self.error_user_registration_disabled)
+end
+
+function SyncsController:update_password()
+    local username = self.request.headers['x-auth-user']
+    local current_key = self.request.headers['x-auth-key']
+    if not is_valid_key_field(username) or not is_valid_field(current_key) then
+        self:raise_error(self.error_unauthorized_user)
+    end
+
+    local body = self.request.body
+    if type(body) ~= "table" or not is_valid_field(body.password) then
+        self:raise_error(self.error_invalid_fields)
+    end
+
+    local redis = self:getRedis()
+    local updated, err = redis:eval(update_password_script, 1,
+        string.format(self.user_key, username), current_key, body.password)
+    if updated == 0 then
+        self:raise_error(self.error_unauthorized_user)
+    elseif updated ~= 1 then
+        self:raise_error(self.error_internal)
+    end
+
+    return 200, { updated = true }
 end
 
 function SyncsController:get_progress()

--- a/config/routes.lua
+++ b/config/routes.lua
@@ -11,6 +11,7 @@ else
     v1:POST("/users/create", { controller = "syncs", action = "create_user_disabled" })
 end
 v1:GET("/users/auth", { controller = "syncs", action = "auth_user" })
+v1:PUT("/users/password", { controller = "syncs", action = "update_password" })
 v1:PUT("/syncs/progress", { controller = "syncs", action = "update_progress" })
 v1:GET("/syncs/progress/:document", { controller = "syncs", action = "get_progress" })
 v1:GET("/healthcheck", { controller = "syncs", action = "healthcheck" })

--- a/spec/controllers/1/syncs_controller_spec.lua
+++ b/spec/controllers/1/syncs_controller_spec.lua
@@ -42,6 +42,21 @@ describe("SyncsController", function()
         return response
     end
 
+    local function update_password(username, userkey, password)
+        local response = hit({
+            scheme = "https",
+            method = "PUT",
+            path = "/users/password",
+            headers = {
+                ["x-auth-user"] = username,
+                ["x-auth-key"] = userkey,
+            },
+            body = { password = password },
+        })
+
+        return response
+    end
+
     local function get(username, userkey, document)
         local response = hit({
             scheme = "https",
@@ -56,7 +71,7 @@ describe("SyncsController", function()
         return response
     end
 
-    local function update(username, userkey, document, percentage, progress, device)
+    local function update(username, userkey, document, percentage, progress, device, device_id)
         local response = hit({
             scheme = "https",
             method = "PUT",
@@ -70,6 +85,7 @@ describe("SyncsController", function()
                 progress = progress,
                 percentage = percentage,
                 device = device,
+                device_id = device_id,
             }
         })
 
@@ -108,6 +124,143 @@ describe("SyncsController", function()
             response = authorize(username, userkey)
             assert.are.same(200, response.status)
             assert.are.same("OK", response.body.authorized)
+        end)
+    end)
+
+    describe("#password", function()
+        local function redis_client()
+            local redis = require("redis")
+            local client = redis.connect("127.0.0.1", 6379)
+            client:select(2)
+            return client
+        end
+
+        local function assert_unauthorized(response)
+            assert.are.same(401, response.status)
+            assert.are.same({code = 2001, message = "Unauthorized"}, response.body)
+        end
+
+        it("replaces the authentication key without changing the username", function()
+            assert.are.same(201, register("reader", "old-key").status)
+            local response = update_password("reader", "old-key", "new-key")
+            assert.are.same(200, response.status)
+            assert.are.same({ updated = true }, response.body)
+            assert_unauthorized(authorize("reader", "old-key"))
+            assert.are.same(200, authorize("reader", "new-key").status)
+        end)
+
+        it("rejects missing, empty, invalid and incorrect authentication", function()
+            register("reader", "old-key")
+            assert_unauthorized(update_password(nil, "old-key", "new-key"))
+            assert_unauthorized(update_password("", "old-key", "new-key"))
+            assert_unauthorized(update_password("reader:other", "old-key", "new-key"))
+            assert_unauthorized(update_password("reader", nil, "new-key"))
+            assert_unauthorized(update_password("reader", "", "new-key"))
+            assert_unauthorized(update_password("reader", "wrong-key", "new-key"))
+            assert.are.same(200, authorize("reader", "old-key").status)
+            assert_unauthorized(authorize("reader", "new-key"))
+        end)
+
+        it("never creates a nonexistent account", function()
+            assert_unauthorized(update_password("missing", "old-key", "new-key"))
+            local client = redis_client()
+            assert.is_nil(client:get("user:missing:key"))
+            client:quit()
+        end)
+
+        it("rejects missing and invalid replacement keys without changing the account", function()
+            register("reader", "old-key")
+            local responses = {
+                update_password("reader", "old-key", nil),
+                update_password("reader", "old-key", ""),
+                update_password("reader", "old-key", 123),
+                update_password("reader", "old-key", false),
+                update_password("reader", "old-key", {}),
+            }
+            for _, response in ipairs(responses) do
+                assert.are.same(403, response.status)
+                assert.are.same({ code = 2003, message = "Invalid request" }, response.body)
+            end
+            assert.are.same(200, authorize("reader", "old-key").status)
+        end)
+
+        it("rejects stale retries and allows confirmation using the replacement key", function()
+            register("reader", "old-key")
+            assert.are.same(200, update_password("reader", "old-key", "new-key").status)
+            assert_unauthorized(update_password("reader", "old-key", "new-key"))
+            assert_unauthorized(update_password("reader", "old-key", "different-key"))
+            assert.are.same(200, authorize("reader", "new-key").status)
+            assert_unauthorized(authorize("reader", "different-key"))
+            assert.are.same(200, update_password("reader", "new-key", "next-key").status)
+            assert_unauthorized(authorize("reader", "new-key"))
+            assert.are.same(200, authorize("reader", "next-key").status)
+        end)
+
+        it("allows an authenticated request to retain its current key", function()
+            register("reader", "same-key")
+            assert.are.same(200, update_password("reader", "same-key", "same-key").status)
+            assert.are.same(200, authorize("reader", "same-key").status)
+        end)
+
+        it("preserves every progress field and other accounts", function()
+            register("reader", "old-key")
+            register("reader-other", "other-key")
+            local documents = { "document1", "document2" }
+            local saved = {}
+            for _, document in ipairs(documents) do
+                assert.are.same(200, update("reader", "old-key", document,
+                    0.32, "56", "reader device", "device1").status)
+                saved[document] = get("reader", "old-key", document).body
+            end
+            local client = redis_client()
+            client:set("user:reader:metadata", "unchanged")
+            client:quit()
+            assert.are.same(200, update_password("reader", "old-key", "new-key").status)
+            for _, document in ipairs(documents) do
+                local response = get("reader", "new-key", document)
+                assert.are.same(200, response.status)
+                assert.are.same(saved[document], response.body)
+                assert_unauthorized(get("reader", "old-key", document))
+            end
+            assert_unauthorized(update("reader", "old-key", documents[1],
+                0.99, "99", "old device"))
+            assert.are.same(200, update("reader", "new-key", documents[1],
+                0.4, "60", "new device").status)
+            assert.are.same("60", get("reader", "new-key", documents[1]).body.progress)
+            assert.are.same(200, authorize("reader-other", "other-key").status)
+            client = redis_client()
+            assert.are.same("unchanged", client:get("user:reader:metadata"))
+            client:quit()
+        end)
+
+        it("does not use a body username to target a different account", function()
+            register("reader", "old-key")
+            register("other", "other-key")
+            local response = hit({
+                scheme = "https",
+                method = "PUT",
+                path = "/users/password",
+                headers = {
+                    ["x-auth-user"] = "reader",
+                    ["x-auth-key"] = "old-key",
+                },
+                body = { username = "other", password = "new-key" },
+            })
+            assert.are.same(200, response.status)
+            assert.are.same(200, authorize("reader", "new-key").status)
+            assert.are.same(200, authorize("other", "other-key").status)
+        end)
+
+        it("returns a generic server error on Redis failure without replacing the key", function()
+            local client = redis_client()
+            client:lpush("user:reader:key", "wrong-type")
+            client:quit()
+            local response = update_password("reader", "old-key", "new-key")
+            assert.are.same(502, response.status)
+            assert.are.same({ code = 2000, message = "Unknown server error." }, response.body)
+            client = redis_client()
+            assert.are.same({ "wrong-type" }, client:lrange("user:reader:key", 0, -1))
+            client:quit()
         end)
     end)
 


### PR DESCRIPTION
Adds `PUT /users/password` so users can change their authentication key while preserving their username and reading progress.

Requests provide the current credentials through `x-auth-user` and `x-auth-key`, with the replacement key in a JSON body: `{"password":"<new-key>"}`. As with registration, the server stores the client-supplied key without hashing it again.

The current-key check and replacement run atomically in Redis, preventing competing changes with the same old key and different replacements from both succeeding. Success returns `200 {"updated":true}`, and subsequent requests must use the replacement key.

The endpoint requires current credentials; it does not provide forgotten-password recovery. The README documents request formatting and how clients can confirm a change after a lost response.

Includes controller specs for authentication, input validation, key replacement, stale retries, preservation of account data, account isolation, and Redis errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-sync-server/51)
<!-- Reviewable:end -->
